### PR TITLE
Fix gcloud docker arguments

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,4 +19,4 @@ docker build -t guestbook  .
 
 docker tag guestbook "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
 
-gcloud docker push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"
+gcloud docker -- push "${GCR_PREFIX}/${PROJECT_ID}/guestbook"


### PR DESCRIPTION
The latest version of gcloud requires this change or it spits the following warning:
ERROR: gcloud crashed (ArgumentError): argument DOCKER_ARGS: unrecognized args: push eu.gcr.io/build-163116/guestbook
The '--' argument must be specified between gcloud specific args on the left and DOCKER_ARGS on the right.